### PR TITLE
Use TOML.print more extensively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/Manifest.toml
+**Manifest.toml
 .vscode/settings.json
 /docs/build
 docs/src/index.md

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgHelpers"
 uuid = "a562b63c-6e73-49f2-82ca-bd0905bcffd6"
 authors = ["Uwe Fechner <uwe.fechner.msc@gmail.com> and contributors"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -17,4 +17,5 @@ copy_manifest
 project_compat
 juliaversion
 docu
+toml_order
 ```

--- a/src/PkgHelpers.jl
+++ b/src/PkgHelpers.jl
@@ -67,23 +67,6 @@ function freeze(pkg; julia=nothing, relaxed = false, copy_manifest=false)
 end
 
 function freeze1(pkg; julia=nothing, relaxed = false, lowerbound=false, status="", mytoml="")
-    function printkv(io, dict, key)
-        if key in keys(dict)
-            value = dict[key]
-            if key == "authors"
-                println(io, "$key = ", value)
-            else
-                println(io, "$key = \"", value, "\"")
-            end
-        end
-    end
-    function print_section(io, dict, key)
-        if key in keys(dict)
-            println(io)
-            println(io, "[$(key)]")
-            TOML.print(io, dict[key]; sorted=true, by=identity)
-        end
-    end
     if isnothing(julia)
         julia=juliaversion()
     end
@@ -92,21 +75,11 @@ function freeze1(pkg; julia=nothing, relaxed = false, lowerbound=false, status="
         project_file = mytoml
     end
     if compat.count > 0
-        dict = (TOML.parsefile(project_file))
+        dict = TOML.parsefile(project_file)
         push!(compat, ("julia" => julia))
+        dict["compat"] = compat
         open(project_file, "w") do io
-            printkv(io, dict, "name")
-            printkv(io, dict, "uuid")
-            printkv(io, dict, "authors")
-            printkv(io, dict, "version")
-            print_section(io, dict, "deps")
-            print_section(io, dict, "weakdeps")
-            print_section(io, dict, "extensions")
-            println(io)
-            println(io, "[compat]")
-            TOML.print(io, compat; sorted=true, by=identity)
-            print_section(io, dict, "extras")
-            print_section(io, dict, "targets")
+            TOML.print(io, dict; sorted=true, by=identity)
         end
     end
     println("Added $(compat.count) entries to the compat section!")

--- a/src/PkgHelpers.jl
+++ b/src/PkgHelpers.jl
@@ -187,9 +187,13 @@ function docu()
 end
 
 """
-toml_order(key::AbstractString)
+    toml_order(key::AbstractString)
 
 Specify the correct order for the different items of the TOML files.
+The keys `name`, `uuid`, `autors` and `version` occur in that order at the top of the TOML 
+as keys pointing to string values.
+They are followed by the `deps``, `compat`, `extras` and `targets` keys that point to 
+dictionaries a level lower.
 """
 function toml_order(key::S)::Union{Int, S} where {S<:AbstractString}
     d = Dict{String, Int}(

--- a/src/PkgHelpers.jl
+++ b/src/PkgHelpers.jl
@@ -79,7 +79,7 @@ function freeze1(pkg; julia=nothing, relaxed = false, lowerbound=false, status="
         push!(compat, ("julia" => julia))
         dict["compat"] = compat
         open(project_file, "w") do io
-            TOML.print(io, dict; sorted=true, by=identity)
+            TOML.print(io, dict; sorted=true, by=toml_order)
         end
     end
     println("Added $(compat.count) entries to the compat section!")
@@ -184,6 +184,25 @@ function docu()
         Base.run(`xdg-open "docs/build/index.html"`; wait=false)
     end
     nothing
+end
+
+"""
+toml_order(key::AbstractString)
+
+Specify the correct order for the different items of the TOML files.
+"""
+function toml_order(key::S)::Union{Int, S} where {S<:AbstractString}
+    d = Dict{String, Int}(
+        "name" => 10,
+        "uuid" => 20,
+        "authors" => 30,
+        "version" => 40,
+        "deps" => 50,
+        "compat" => 60,
+        "extras" => 70,
+        "targets" => 80,
+    )
+    return get(d, key, key)
 end
 
 end

--- a/src/PkgHelpers.jl
+++ b/src/PkgHelpers.jl
@@ -177,7 +177,7 @@ end
 """
     docu()
 
-Display the HTLM documentation in a browser window.
+Display the HTML documentation in a browser window.
 """
 function docu()
     if Sys.islinux()
@@ -187,7 +187,7 @@ function docu()
 end
 
 """
-    toml_order(key::AbstractString)
+    toml_order(key)
 
 Specify the correct order for the different items of the TOML files.
 The keys `name`, `uuid`, `autors` and `version` occur in that order at the top of the TOML 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,10 +15,14 @@ function tomlcmp(path1::AbstractString, path2::AbstractString)
     dict1 = TOML.parsefile(path1)
     dict2 = TOML.parsefile(path2)
     for key in keys(dict1)
-        if repr(dict1[key])!=repr(dict2[key]); return false; end
+        if repr(dict1[key]) != repr(dict2[key])
+            return false
+        end
     end
     for key in keys(dict2)
-        if repr(dict1[key])!=repr(dict2[key]); return false; end
+        if repr(dict1[key]) != repr(dict2[key])
+            return false
+        end
     end
     true
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,19 +12,13 @@ function comp(vec1, vec2, n)
 end
 
 function tomlcmp(path1::AbstractString, path2::AbstractString)
-    dict1 = TOML.parsefile(path1)
-    dict2 = TOML.parsefile(path2)
-    for key in keys(dict1)
-        if repr(dict1[key]) != repr(dict2[key])
-            return false
+    open(path1) do f1
+        open(path2) do f2
+            for (l1, l2) in zip(readlines(f1), readlines(f2))
+                @test l1 == l2
+            end
         end
     end
-    for key in keys(dict2)
-        if repr(dict1[key]) != repr(dict2[key])
-            return false
-        end
-    end
-    true
 end
 
 st = "Project PkgHelpers v0.1.0\nStatus `~/repos/PkgHelpers.jl/Project.toml`\n  [44cfe95a] Pkg v1.10.0\n  [fa267f1f] TOML v1.0.3\n"
@@ -37,11 +31,11 @@ st = "Project PkgHelpers v0.1.0\nStatus `~/repos/PkgHelpers.jl/Project.toml`\n  
     mydir = mktempdir()
     filename = "test-1.toml"
     filename2 = "test-2.toml"
-    mytoml = joinpath(mydir, filename)
+    @show mytoml = joinpath(mydir, filename)
     cp(filename, mytoml, force=true)
     chmod(mytoml, 0o777)
     PkgHelpers.freeze1(nothing; julia="~1.10", status=st, mytoml=mytoml)
-    @test tomlcmp(filename2, mytoml)
+    tomlcmp(filename2, mytoml)
 end
 @testset "freeze - relaxed" begin
     project_file, compat = PkgHelpers.project_compat(Pkg, true, false; status=st)
@@ -55,7 +49,7 @@ end
     cp(filename, mytoml, force=true)
     chmod(mytoml, 0o777)
     PkgHelpers.freeze1(nothing; julia="~1.10", relaxed=true, status=st, mytoml=mytoml)
-    @test tomlcmp(filename2, mytoml)
+    tomlcmp(filename2, mytoml)
 end
 @testset "lower_bound" begin
     project_file, compat = PkgHelpers.project_compat(Pkg, false, false; status=st)
@@ -69,7 +63,7 @@ end
     cp(filename, mytoml, force=true)
     chmod(mytoml, 0o777)
     PkgHelpers.freeze1(nothing; julia="1.6", lowerbound=true, status=st, mytoml=mytoml)
-    @test tomlcmp(filename2, mytoml)
+    tomlcmp(filename2, mytoml)
 end
 @testset "lower_bound - relaxed" begin
     project_file, compat = PkgHelpers.project_compat(Pkg, false, false; status=st)
@@ -83,5 +77,19 @@ end
     cp(filename, mytoml, force=true)
     chmod(mytoml, 0o777)
     PkgHelpers.freeze1(nothing; julia="1.6", relaxed=true, lowerbound=true, status=st, mytoml=mytoml)
-    @test tomlcmp(filename2, mytoml)
+    tomlcmp(filename2, mytoml)
+end
+@testset "order" begin
+    project_file, compat = PkgHelpers.project_compat(Pkg, false, false; status=st)
+    @test basename(project_file) == "Project.toml"
+    @test haskey(compat, "TOML")
+    @test haskey(compat, "Pkg")
+    mydir = mktempdir()
+    filename = "test-unordered.toml"
+    filename2 = "test-2.toml"
+    mytoml = joinpath(mydir, filename)
+    cp(filename, mytoml, force=true)
+    chmod(mytoml, 0o777)
+    PkgHelpers.freeze1(nothing; julia="~1.10", status=st, mytoml=mytoml)
+    tomlcmp(filename2, mytoml)
 end

--- a/test/test-2.toml
+++ b/test/test-2.toml
@@ -9,8 +9,8 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 Pkg = "=1.10.0"
-julia = "~1.10"
 TOML = "=1.0.3"
+julia = "~1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test-3.toml
+++ b/test/test-3.toml
@@ -9,8 +9,8 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 Pkg = "~1.10"
-julia = "~1.10"
 TOML = "~1.0"
+julia = "~1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test-4.toml
+++ b/test/test-4.toml
@@ -9,8 +9,8 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 Pkg = "1.10.0"
-julia = "1.6"
 TOML = "1.0.3"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test-5.toml
+++ b/test/test-5.toml
@@ -9,8 +9,8 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 Pkg = "1.10"
-julia = "1.6"
 TOML = "1.0"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test-unordered.toml
+++ b/test/test-unordered.toml
@@ -1,0 +1,19 @@
+name = "PkgHelpers"
+uuid = "a562b63c-6e73-49f2-82ca-bd0905bcffd6"
+version = "0.1.0"
+authors = ["Uwe Fechner <uwe.fechner.msc@gmail.com> and contributors"]
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]
+
+[deps]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[compat]
+Pkg = "=1.10.0"
+TOML = "=1.0.3"
+julia = "~1.10"


### PR DESCRIPTION
I can imagine there being a reason _not_ to do this, but if so, there should be a test case embodying that reason.