### PR TITLE
Fix capitalization of pjg when status==""

### DIFF
--- a/src/PkgHelpers.jl
+++ b/src/PkgHelpers.jl
@@ -112,7 +112,7 @@ Returns the tuple (project_file, compat).
 function project_compat(pkg, relaxed, lowerbound; prn=false, status="")
     if status==""
         io = IOBuffer();
-        pkg.status(; io=io)
+        Pkg.status(; io=io)
         st = String(take!(io))
     else
         st = status


### PR DESCRIPTION
I don't know how this happens, and I'm not sure how to test it, but this is quite a major bug at the moment.